### PR TITLE
Fixed depth capture, added conversion to BGR

### DIFF
--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -26,10 +26,10 @@ APIPCamera::APIPCamera()
     PrimaryActorTick.bCanEverTick = true;
 
     image_type_to_pixel_format_map_.Add(0, EPixelFormat::PF_B8G8R8A8);
-    image_type_to_pixel_format_map_.Add(1, EPixelFormat::PF_DepthStencil); // not used. init_auto_format is called in setupCameraFromSettings() 
-    image_type_to_pixel_format_map_.Add(2, EPixelFormat::PF_DepthStencil); // not used for same reason as above
-    image_type_to_pixel_format_map_.Add(3, EPixelFormat::PF_DepthStencil); // not used for same reason as above 
-    image_type_to_pixel_format_map_.Add(4, EPixelFormat::PF_DepthStencil); // not used for same reason as above 
+    image_type_to_pixel_format_map_.Add(1, EPixelFormat::PF_FloatRGBA); // not used. init_auto_format is called in setupCameraFromSettings()
+    image_type_to_pixel_format_map_.Add(2, EPixelFormat::PF_FloatRGBA); // not used for same reason as above
+    image_type_to_pixel_format_map_.Add(3, EPixelFormat::PF_FloatRGBA); // not used for same reason as above
+    image_type_to_pixel_format_map_.Add(4, EPixelFormat::PF_FloatRGBA); // not used for same reason as above
     image_type_to_pixel_format_map_.Add(5, EPixelFormat::PF_B8G8R8A8);
     image_type_to_pixel_format_map_.Add(6, EPixelFormat::PF_B8G8R8A8);
     image_type_to_pixel_format_map_.Add(7, EPixelFormat::PF_B8G8R8A8);
@@ -71,9 +71,7 @@ void APIPCamera::BeginPlay()
     camera_type_enabled_.assign(imageTypeCount(), false);
 
     for (unsigned int image_type = 0; image_type < imageTypeCount(); ++image_type) {
-        //use final color for all calculations
         captures_[image_type]->CaptureSource = ESceneCaptureSource::SCS_FinalColorLDR;
-
         render_targets_[image_type] = NewObject<UTextureRenderTarget2D>();
     }
 

--- a/Unreal/Plugins/AirSim/Source/RenderRequest.cpp
+++ b/Unreal/Plugins/AirSim/Source/RenderRequest.cpp
@@ -25,7 +25,6 @@ void RenderRequest::FastScreenshot()
 
     UAirBlueprintLib::RunCommandOnGameThread([this]() {
         fast_rt_resource_ = fast_param_.render_component->TextureTarget->GameThread_GetRenderTargetResource();
-        fast_param_.render_component->CaptureScene();
         ENQUEUE_RENDER_COMMAND(SceneDrawCompletion)([this](FRHICommandListImmediate& RHICmdList)
         {
             this->RenderThreadScreenshotTask(this->latest_result_);
@@ -49,38 +48,104 @@ void RenderRequest::RenderThreadScreenshotTask(RenderRequest::RenderResult &resu
     result.height = height;
     result.time_stamp = msr::airlib::ClockFactory::get()->nowNanos();
 
-    uint32 stride;
+    uint32 stride; // The number of bytes per row of image data (may include padding)
     auto *src = (const uint8_t*)RHILockTexture2D(fast_cap_texture, 0, RLM_ReadOnly, stride, false); // needs to be on render thread
-    
-    result.stride = stride;
-    size_t size = height * stride;
-
-    UE_LOG(LogTemp, Warning, TEXT("stats: H: %d,  W: %d,  S: %d,  px_format: %d"),
-                                    height, width, stride, pixelFormat);
 
     if (src) {
         switch (pixelFormat) {
         case PF_B8G8R8A8:
-            result.pixels_as_float = false;
-            result.pixels = buffer_pool_->GetBufferExactSize(size);
-            FMemory::BigBlockMemcpy(result.pixels->data(), src, size);
-            break;
+            {
+                result.pixels_as_float = false;
+
+                /*
+                * Calculate the exact image size from the width, height, and
+                * number of components
+                */
+                result.pixels = buffer_pool_->GetBufferExactSize(
+                    width * height * 3);
+                // The stride should exactly fit the image.
+                result.stride = result.width * 3;
+
+                // Convert the data to BGR8
+                uint8* dst = result.pixels->data();
+                bgra8ToBgr8(dst, src, width, height, stride);
+
+                break;
+            }
 
         case PF_FloatRGBA:
-            result.pixels_as_float = true;
-            result.pixels_float = buffer_pool_float_->GetBufferExactSize(size);
-            FMemory::BigBlockMemcpy(result.pixels_float->data(), src, size);
-            break;
+            {
+                result.pixels_as_float = true;
+
+                /*
+                * Calculate the exact image size from the width, height, number
+                * of components, and size of each component
+                */
+                result.pixels_float = buffer_pool_float_->GetBufferExactSize(
+                    width * height * sizeof(float));
+                // The stride should exactly fit the image.
+                result.stride = result.width * sizeof(float);
+
+                /*
+                * We're using a depth buffer, where the depth is stored in the R
+                * component. FloatRGBA is misleading, as it should actually be
+                * Float16RGBA, or HalfFloatRGBA, because each component is
+                * represented by a 16 bit float and not a 32 bit float.
+                */
+                float* dst = result.pixels_float->data();
+                rgba16fToDepthFloat(dst, src, width, height, stride);
+
+                break;
+            }
 
         default:
             UE_LOG(LogTemp, Warning, TEXT("Unexpected pixel format: %d"), pixelFormat);
             break;
         }
     }
-    
+
     RHIUnlockTexture2D(fast_cap_texture, 0, false);
 
     std::unique_lock<std::mutex> lck(mtx_);
     fast_cap_done_ = true;
     cv_.notify_all();
+}
+
+void RenderRequest::bgra8ToBgr8(
+    uint8* dst,
+    const uint8* src,
+    uint32 width,
+    uint32 height,
+    uint32 stride)
+{
+    for (uint32 i = 0; i < width; i++)
+    {
+        for (uint32 j = 0; j < height; j++)
+        {
+            memcpy(
+                &dst[(i + j * width) * 3],
+                &src[i * 4 + j * stride],
+                3 * sizeof(uint8));
+        }
+    }
+}
+
+void RenderRequest::rgba16fToDepthFloat(
+    float* dst,
+    const uint8* src,
+    uint32 width,
+    uint32 height,
+    uint32 stride)
+{
+    for (uint32 i = 0; i < width; i++)
+    {
+        for (uint32 j = 0; j < height; j++)
+        {
+            // Decode the R component and store it in the array
+            int index0 = i * 8 + j * stride;
+            FFloat16 val;
+            val.Encoded = src[index0 + 0] | (src[index0 + 1] << 8);
+            dst[i + j * width] = val;
+        }
+    }
 }

--- a/Unreal/Plugins/AirSim/Source/RenderRequest.h
+++ b/Unreal/Plugins/AirSim/Source/RenderRequest.h
@@ -69,4 +69,39 @@ public:
 
     void FastScreenshot();
     void RenderThreadScreenshotTask(RenderResult &result);
+
+private:
+    /**
+     * \brief Converts BGRA8 data to BGR8 data.
+     *
+     * \param[out] dst     The image data to write to
+     * \param[in]  src     The image data to convert
+     * \param[in]  width   The width of the input image
+     * \param[in]  height  The height of the input image
+     * \param[in]  stride  The stride (bytes per line) of the input image
+     */
+    static void bgra8ToBgr8(
+        uint8* dst,
+        const uint8* src,
+        uint32 width,
+        uint32 height,
+        uint32 stride);
+
+    /**
+     * \brief
+     *     Extracts the red component from RGBA16F (AKA PF_FloatRGBA), converts
+     *     it to float data, and then converts it from centimeters to meters
+     *
+     * \param[out] dst     The image data to write to
+     * \param[in]  src     The image data to convert
+     * \param[in]  width   The width of the input image
+     * \param[in]  height  The height of the input image
+     * \param[in]  stride  The stride (bytes per line) of the input image
+     */
+    static void rgba16fToDepthFloat(
+        float* dst,
+        const uint8* src,
+        uint32 width,
+        uint32 height,
+        uint32 stride);
 };


### PR DESCRIPTION
Hi @rajat2004,

I wasn't sure if I should create a pull request here, or do it somewhere else - I'm still fairly new to GitHub. Anyway, I made some changes that should make depth images work with the faster image capture. I tested it on a custom environment. I also added some code to convert from BGRA8 to BGR8. As far as I can tell, there is no better way to do this. I tried using R16F as the depth format instead of FloatRGBA, but that doesn't seem to be possible. I also removed calling `fast_rt_resource_->Capture()`, as this seems to not be necessary and is the source of some warnings. Some changes are probably necessary for DepthViz. I get around 30 FPS while running without capturing images, and around 20 FPS when capturing a 256x144 depth image, and a 256x144 color image as fast as possible.

Any comments and testing are appreciated. Please let me know if you have any questions as well. Thanks!

Best,
Tom