### PR TITLE
Added the functionality for getting images from the external cameras.…

### DIFF
--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -97,6 +97,8 @@ public:
 
     vector<ImageCaptureBase::ImageResponse> simGetImages(vector<ImageCaptureBase::ImageRequest> request, const std::string& vehicle_name = "");
     vector<uint8_t> simGetImage(const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name = "");
+    vector<ImageCaptureBase::ImageResponse> simGetExternalImages(vector<ImageCaptureBase::ImageRequest> request);
+    vector<uint8_t> simGetExternalImage(const std::string& camera_name, ImageCaptureBase::ImageType type);
 
     vector<MeshPositionVertexBuffersResponse> simGetMeshPositionVertexBuffers();
 

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -4,7 +4,9 @@
 #ifndef air_WorldSimApiBase_hpp
 #define air_WorldSimApiBase_hpp
 
+#include <vector>
 #include "common/CommonStructs.hpp"
+#include "common/ImageCaptureBase.hpp"
 
 namespace msr { namespace airlib {
 
@@ -77,15 +79,12 @@ public:
 
     // Image APIs
     virtual CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const = 0;
-    virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
-                               const std::string& vehicle_name = "", bool external = false) = 0;
-    virtual void setCameraFoV(const std::string& camera_name, float fov_degrees,
-                              const std::string& vehicle_name = "", bool external = false) = 0;
-    virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
-                                    const std::string& vehicle_name = "", bool external = false) = 0;
-    virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "",
-                                                    bool external = false) const = 0;
-
+    virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose, const std::string& vehicle_name = "", bool external = false) = 0;
+    virtual void setCameraFoV(const std::string& camera_name, float fov_degrees, const std::string& vehicle_name = "", bool external = false) = 0;
+    virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value, const std::string& vehicle_name = "", bool external = false) = 0;
+    virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const = 0;
+    virtual vector<uint8_t> getExternalImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const = 0;
+    virtual std::vector<ImageCaptureBase::ImageResponse> getExternalImages(const vector<ImageCaptureBase::ImageRequest>& requests) const = 0;
 };
 
 

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -242,6 +242,22 @@ vector<uint8_t> RpcLibClientBase::simGetImage(const std::string& camera_name, Im
     return result;
 }
 
+vector<ImageCaptureBase::ImageResponse> RpcLibClientBase::simGetExternalImages(vector<ImageCaptureBase::ImageRequest> request)
+{
+    const auto& response_adaptor = pimpl_->client.call("simGetExternalImages", RpcLibAdapatorsBase::ImageRequest::from(request)).as<vector<RpcLibAdapatorsBase::ImageResponse>>();
+    return RpcLibAdapatorsBase::ImageResponse::to(response_adaptor);
+}
+
+vector<uint8_t> RpcLibClientBase::simGetExternalImage(const std::string& camera_name, ImageCaptureBase::ImageType type)
+{
+    vector<uint8_t> result = pimpl_->client.call("simGetExternalImage", camera_name, type).as<vector<uint8_t>>();
+    if (result.size() == 1) {
+        // rpclib has a bug with serializing empty vectors, so we return a 1 byte vector instead.
+        result.clear();
+    }
+    return result;
+}
+
 vector<MeshPositionVertexBuffersResponse> RpcLibClientBase::simGetMeshPositionVertexBuffers()
 {
     const auto& response_adaptor = pimpl_->client.call("simGetMeshPositionVertexBuffers").as<vector<RpcLibAdapatorsBase::MeshPositionVertexBuffersResponse>>();

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -144,6 +144,16 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
         return getVehicleSimApi(vehicle_name)->getImage(camera_name, type);
     });
 
+    pimpl_->server.bind("simGetExternalImages", [&](const std::vector<RpcLibAdapatorsBase::ImageRequest>& request_adapter) ->
+        vector<RpcLibAdapatorsBase::ImageResponse> {
+            const auto& response = getWorldSimApi()->getExternalImages(RpcLibAdapatorsBase::ImageRequest::to(request_adapter));
+            return RpcLibAdapatorsBase::ImageResponse::from(response);
+    });
+    
+    pimpl_->server.bind("simGetExternalImage", [&](const std::string& camera_name, ImageCaptureBase::ImageType type) -> vector<uint8_t> {
+        return getWorldSimApi()->getExternalImage(camera_name, type);
+    });
+
     pimpl_->server.bind("simGetMeshPositionVertexBuffers", [&]() ->vector<RpcLibAdapatorsBase::MeshPositionVertexBuffersResponse> {
         const auto& response = getWorldSimApi()->getMeshPositionVertexBuffers();
         return RpcLibAdapatorsBase::MeshPositionVertexBuffersResponse::from(response);

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -255,6 +255,52 @@ class VehicleClient:
         responses_raw = self.client.call('simGetImages', requests, vehicle_name)
         return [ImageResponse.from_msgpack(response_raw) for response_raw in responses_raw]
 
+        # camera control
+    # simGetImage returns compressed png in array of bytes
+    # image_type uses one of the ImageType members
+    def simGetExternalImages(self, requests):
+        """
+        Get multiple images
+
+        See https://microsoft.github.io/AirSim/image_apis/ for details and examples
+
+        Args:
+            requests (list[ImageRequest]): Images required
+            vehicle_name (str, optional): Name of vehicle associated with the camera
+
+        Returns:
+            list[ImageResponse]:
+        """
+        responses_raw = self.client.call('simGetExternalImages', requests)
+        return [ImageResponse.from_msgpack(response_raw) for response_raw in responses_raw]
+    # camera control
+    # simGetImage returns compressed png in array of bytes
+    # image_type uses one of the ImageType members
+    def simGetExternalImage(self, camera_name, image_type):
+        """
+        Get a single image
+
+        Returns bytes of png format image which can be dumped into abinary file to create .png image
+        `string_to_uint8_array()` can be used to convert into Numpy unit8 array
+        See https://microsoft.github.io/AirSim/image_apis/ for details
+
+        Args:
+            camera_name (str): Name of the camera, for backwards compatibility, ID numbers such as 0,1,etc. can also be used
+            image_type (ImageType): Type of image required
+            vehicle_name (str, optional): Name of the vehicle with the camera
+
+        Returns:
+            Binary string literal of compressed png image
+        """
+        # todo: in future remove below, it's only for compatibility to pre v1.2
+        camera_name = str(camera_name)
+
+        # because this method returns std::vector<uint8>, msgpack decides to encode it as a string unfortunately.
+        result = self.client.call('simGetExternalImage', camera_name, image_type)
+        if (result == "" or result == "\0"):
+            return None
+        return result
+
     def simRunConsoleCommand(self, command):
         """
         Allows the client to execute a command in Unreal's native console, via an API.

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -506,6 +506,32 @@ const APIPCamera* ASimModeBase::getCamera(const std::string& camera_name, const 
         return getVehicleSimApi(vehicle_name)->getCamera(camera_name);
 }
 
+std::vector<ASimModeBase::ImageCaptureBase::ImageResponse> ASimModeBase::getExternalImages(const std::vector<ImageCaptureBase::ImageRequest>& requests) const
+{
+    std::vector<ImageCaptureBase::ImageResponse> responses;
+
+    const ImageCaptureBase* camera = getExternalImageCapture();
+    camera->getImages(requests, responses);
+
+    return responses;
+}
+
+std::vector<uint8_t> ASimModeBase::getExternalImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const
+{
+    std::vector<ImageCaptureBase::ImageRequest> request = { ImageCaptureBase::ImageRequest(camera_name, image_type) };
+    const std::vector<ImageCaptureBase::ImageResponse>& response = getExternalImages(request);
+
+    if (response.size() > 0)
+        return response.at(0).image_data_uint8;
+    else
+        return std::vector<uint8_t>();
+}
+
+const UnrealImageCapture* ASimModeBase::getExternalImageCapture() const
+{
+    return external_image_capture_.get();
+}
+
 //API server start/stop
 void ASimModeBase::startApiServer()
 {
@@ -667,6 +693,7 @@ void ASimModeBase::setupVehiclesAndCamera()
 
     // Create External Cameras
     initializeExternalCameras();
+    external_image_capture_.reset(new UnrealImageCapture(&external_cameras_));
 
     if (getApiProvider()->hasDefaultVehicle()) {
         //TODO: better handle no FPV vehicles scenario

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -5,6 +5,7 @@
 #include "Engine/DirectionalLight.h"
 #include "GameFramework/Actor.h"
 #include "ParticleDefinitions.h"
+#include "UnrealImageCapture.h"
 
 #include <string>
 #include "CameraDirector.h"
@@ -23,7 +24,9 @@ UCLASS()
 class AIRSIM_API ASimModeBase : public AActor
 {
 public:
-
+	//types
+	typedef msr::airlib::ImageCaptureBase ImageCaptureBase;
+	
     GENERATED_BODY()
 
     UPROPERTY(BlueprintAssignable, BlueprintCallable)
@@ -108,6 +111,11 @@ public:
             static_cast<const ASimModeBase*>(this)->getCamera(camera_name, vehicle_name, external));
     } 
 
+    //image APIs
+    std::vector<ASimModeBase::ImageCaptureBase::ImageResponse> getExternalImages(const std::vector<ImageCaptureBase::ImageRequest>& requests) const;
+    std::vector<uint8_t> getExternalImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const;
+    const UnrealImageCapture* getExternalImageCapture() const;
+
     TMap<FString, FAssetData> asset_map;
     TMap<FString, AActor*> scene_object_map;
 
@@ -182,7 +190,6 @@ private:
     msr::airlib::StateReporterWrapper debug_reporter_;
 
     std::vector<std::unique_ptr<msr::airlib::VehicleSimApiBase>> vehicle_sim_apis_;
-    common_utils::UniqueValueMap<std::string, APIPCamera*> external_cameras_;
 
     UPROPERTY()
         TArray<AActor*> spawned_actors_; //keep refs alive from Unreal GC
@@ -190,6 +197,11 @@ private:
     bool lidar_checks_done_ = false; 
     bool lidar_draw_debug_points_ = false;
     static ASimModeBase* SIMMODE;
+
+    //Image API
+    common_utils::UniqueValueMap<std::string, APIPCamera*> external_cameras_;
+    std::unique_ptr<UnrealImageCapture> external_image_capture_;
+
 private:
     void setStencilIDs();
     void initializeTimeOfDay();

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -559,6 +559,19 @@ void WorldSimApi::setWind(const Vector3r& wind) const
     simmode_->setWind(wind);
 }
 
+//Image APIs
+std::vector<WorldSimApi::ImageCaptureBase::ImageResponse> WorldSimApi::getExternalImages(const vector<ImageCaptureBase::ImageRequest>& requests) const
+{
+    std::vector<ImageCaptureBase::ImageResponse> responses = simmode_->getExternalImages(requests);
+    return responses;	
+}
+
+vector<uint8_t> WorldSimApi::getExternalImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const
+{
+    std::vector<uint8_t> outputImg = simmode_->getExternalImage(camera_name, image_type);
+    return outputImg;	
+}
+
 CameraInfo WorldSimApi::getCameraInfo(const std::string& camera_name, const std::string& vehicle_name, bool external) const
 {
     CameraInfo info;

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -8,12 +8,14 @@
 #include "Runtime/Engine/Classes/Engine/StaticMesh.h"
 #include "Engine/LevelStreamingDynamic.h" 
 #include <string>
+#include <vector>
 
 class WorldSimApi : public msr::airlib::WorldSimApiBase {
 public:
     typedef msr::airlib::Pose Pose;
     typedef msr::airlib::Vector3r Vector3r;
     typedef msr::airlib::MeshPositionVertexBuffersResponse MeshPositionVertexBuffersResponse;
+    typedef msr::airlib::ImageCaptureBase ImageCaptureBase;
 
     WorldSimApi(ASimModeBase* simmode);
     virtual ~WorldSimApi() = default;
@@ -69,15 +71,12 @@ public:
 
     // Image APIs
     virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const override;
-    virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
-                               const std::string& vehicle_name = "", bool external = false) override;
-    virtual void setCameraFoV(const std::string& camera_name, float fov_degrees,
-                              const std::string& vehicle_name = "", bool external = false) override;
-    virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
-                                    const std::string& vehicle_name = "", bool external = false) override;
-    virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "",
-                                                    bool external = false) const override;
-
+    virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose, const std::string& vehicle_name = "", bool external = false) override;
+    virtual void setCameraFoV(const std::string& camera_name, float fov_degrees, const std::string& vehicle_name = "", bool external = false) override;
+    virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value, const std::string& vehicle_name = "", bool external = false) override;
+    virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const override;
+	virtual std::vector<uint8_t> getExternalImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const override;
+	virtual std::vector<ImageCaptureBase::ImageResponse> getExternalImages(const std::vector<ImageCaptureBase::ImageRequest>& requests) const override;
 
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);


### PR DESCRIPTION
… The functions simGetExternalImages and simGetExternalImage can be called from the Python API. They work the same as simGetimages/simGetImage counterparts, but you do not need to specify the vehicle name. 

<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->


## About
Arguably, to be in line with @rajat2004 changes, it would make sense to modify the existing simGetImages/simGetImage functions (as this is basically a copy/paste of them into SimModeBase). However, I would argue that it makes more sense to have a separate funct as the simGetImages/simGetImage have a vehicle_name input which would make it confusing for this, as the external cameras do not require a vehicle name. This could be left blank of course, and a bool argument could be added as with the other functions. In that case, an if/else would determine which function is called within RpcLibServerBase.cpp based on the value of the bool. 

I would be open to change this. 

## How Has This Been Tested?
Tested by adding the "fixed1" camera to settings.json and running in Unreal. 

API call:
```
responses = client.simGetExternalImages([
    airsim.ImageRequest("fixed1", airsim.ImageType.Segmentation, False, False ),
    airsim.ImageRequest("fixed1", airsim.ImageType.Scene)]) 

response = client.simGetExternalImage("fixed1", airsim.ImageType.Scene)
```
This can be run within hello_drone.py, by replacing the simGetImages with simGetExternalImages code shown. 

